### PR TITLE
Game API offers inclusion of available moves when querying board state

### DIFF
--- a/GameAPI/OthelloGameAPI/Controllers/OthelloGameController.cs
+++ b/GameAPI/OthelloGameAPI/Controllers/OthelloGameController.cs
@@ -25,9 +25,9 @@ namespace OthelloGameAPI.Controllers
         }
 
         [HttpGet("Board")]
-        public IActionResult GetBoard()
+        public IActionResult GetBoard([FromQuery] bool indicateMoveOptions = false)
         {
-            int[][] matrix = Service.GetGameBoard();
+            int[][] matrix = Service.GetGameBoard(indicateMoveOptions);
             return Ok(matrix);
         }
 

--- a/GameAPI/OthelloGameAPI/Services/OthelloGameService.cs
+++ b/GameAPI/OthelloGameAPI/Services/OthelloGameService.cs
@@ -13,11 +13,26 @@ namespace OthelloGameAPI.Services
             Game = new OthelloGame();
         }
 
-        public int[][] GetGameBoard()
+        public int[][] GetGameBoard(bool indicateMoveOptions = false)
         {
             int[,] board = Game.Board;
             int[][] matrix = CreateJaggedMatrix(board);
+
+            if (indicateMoveOptions)
+            {
+                List<OthelloMove> moves = Game.AvailableMoves;
+                EncodeMoveOptions(matrix, moves);
+            }
+
             return matrix;
+        }
+
+        private void EncodeMoveOptions(int[][] board, List<OthelloMove> moves)
+        {
+            foreach(OthelloMove move in moves)
+            {
+                board[move.Row][move.Col] = 5;
+            }
         }
 
         private static int[][] CreateJaggedMatrix(int[,] grid)


### PR DESCRIPTION
- added optional indicateMoveOptions parameter to Game API @ GET /board
- available moves are encoded as '5'

```http://localhost:5079/OthelloGame/Board?indicateMoveOptions=true```

<img width="595" height="428" alt="image" src="https://github.com/user-attachments/assets/0b1b21d8-0169-42a5-8c3f-b43e2ffbe09f" />
