### PR TITLE
Added Opponent Service to Game API, Gameplay SPA is now Black-only

### DIFF
--- a/GameAPI/OthelloGameAPI/Controllers/OthelloGameController.cs
+++ b/GameAPI/OthelloGameAPI/Controllers/OthelloGameController.cs
@@ -11,10 +11,12 @@ namespace OthelloGameAPI.Controllers
     public class OthelloGameController : ControllerBase
     {
         private OthelloGameService Service;
+        private OpponentService Opponent;
 
-        public OthelloGameController(OthelloGameService service)
+        public OthelloGameController(OthelloGameService service, OpponentService opponent)
         {
             Service = service;
+            Opponent = opponent;
         }
 
         [HttpGet("GameInfo")]
@@ -45,14 +47,12 @@ namespace OthelloGameAPI.Controllers
             return Ok();
         }
 
-
         [HttpPost("Pass")]
         public IActionResult SubmitPass([FromQuery] int player)
         {
             Service.AttemptPass(player);
             return Ok();
         }
-
 
         [HttpPost("NewGame")]
         public IActionResult StartNewGame()

--- a/GameAPI/OthelloGameAPI/Controllers/OthelloGameController.cs
+++ b/GameAPI/OthelloGameAPI/Controllers/OthelloGameController.cs
@@ -19,6 +19,25 @@ namespace OthelloGameAPI.Controllers
             Opponent = opponent;
         }
 
+        private async Task TriggerOpponentResponseAttempt()
+        {
+            if (Service.GetTurnPlayer() == 1 || Service.Game.GameOver)
+            {
+                return;
+            }
+
+            OthelloMove? possibleMove = await Opponent.GetOpponentMove(Service.Game);
+            if (possibleMove is OthelloMove move)
+            {
+                Service.Game.AttemptMove(move);
+            }
+            else
+            {
+                Service.Game.AttemptPass();
+            }
+        }
+
+
         [HttpGet("GameInfo")]
         public IActionResult GetGameInfo()
         {
@@ -44,6 +63,7 @@ namespace OthelloGameAPI.Controllers
         public IActionResult SubmitMove([FromBody] MoveDataObject move)
         {
             Service.AttemptMove(move);
+            _ = TriggerOpponentResponseAttempt();
             return Ok();
         }
 
@@ -51,6 +71,7 @@ namespace OthelloGameAPI.Controllers
         public IActionResult SubmitPass([FromQuery] int player)
         {
             Service.AttemptPass(player);
+            _ = TriggerOpponentResponseAttempt();
             return Ok();
         }
 

--- a/GameAPI/OthelloGameAPI/Program.cs
+++ b/GameAPI/OthelloGameAPI/Program.cs
@@ -16,6 +16,7 @@ namespace OthelloGameAPI
             builder.Services.AddEndpointsApiExplorer();
             builder.Services.AddSwaggerGen();
             builder.Services.AddSingleton<OthelloGameService>();
+            builder.Services.AddScoped<OpponentService>();
 
             builder.Services.AddCors(options =>
             {

--- a/GameAPI/OthelloGameAPI/Services/OpponentService.cs
+++ b/GameAPI/OthelloGameAPI/Services/OpponentService.cs
@@ -1,0 +1,40 @@
+﻿using LibOthello;
+
+namespace OthelloGameAPI.Services
+{
+    public class OpponentService
+    {
+        private Random Random = new Random();
+
+        public async Task<OthelloMove?> GetOpponentMove(OthelloGame game)
+        {
+            double bestScore = 0.0;
+            OthelloMove? bestMove = null;
+
+            foreach(OthelloMove move in game.AvailableMoves)
+            {
+                double score = await GetMoveScore(move, game);
+                if (score > bestScore)
+                {
+                    bestMove = move;
+                    bestScore = score;
+                }
+            }
+
+            return bestMove;
+        }
+
+        private async Task<double> GetMoveScore(OthelloMove move, OthelloGame game)
+        {
+            OthelloGame futureGame = new OthelloGame(game);
+            futureGame.AttemptMove(move);
+            return await GetScoreForGameState(futureGame);
+        }
+
+        private async Task<double> GetScoreForGameState(OthelloGame game)
+        {
+            await Task.Delay(25);
+            return Random.NextDouble();
+        }
+    }
+}

--- a/GameplaySPA/src/App.tsx
+++ b/GameplaySPA/src/App.tsx
@@ -11,7 +11,6 @@ import { GameInfo, getDummyGameInfo } from './services/GameInfoService';
 
 import { fetchGameState } from './services/GameStateService';
 
-
 function App() {
   const [tiles, setTiles] = useState<Piece[]>(() => createEmptyBoard());
   const [gameInfo, setGameInfo] = useState<GameInfo>(() => getDummyGameInfo());
@@ -41,6 +40,29 @@ function App() {
       .then(refreshGameState)
       .catch(console.error);
   };
+
+  useEffect(() => {
+    let cancelled = false;
+    let fetching = false;
+
+    const tick = async () => {
+      if (fetching) return;
+      fetching = true;
+      try {
+        const { tiles, gameInfo } = await fetchGameState();
+        if (!cancelled) {
+          setTiles(tiles);
+          setGameInfo(gameInfo);
+        }
+      } finally {
+        fetching = false;
+      }
+    };
+
+    tick();
+    const id = setInterval(tick, 800);
+    return () => { cancelled = true; clearInterval(id); };
+  }, []);
 
   return (
     <>

--- a/GameplaySPA/src/App.tsx
+++ b/GameplaySPA/src/App.tsx
@@ -25,7 +25,7 @@ function App() {
   useEffect(() => { refreshGameState().catch(console.error); }, []);
 
   const handleTileClick = (i: number, j: number) => {
-    submitMove(gameInfo.TurnPlayer, i, j)
+    submitMove(1, i, j) // '1' here forces playing as black only
       .then(refreshGameState)
       .catch(console.error);
   };

--- a/GameplaySPA/src/services/GameStateService.tsx
+++ b/GameplaySPA/src/services/GameStateService.tsx
@@ -4,6 +4,16 @@ import { getGameInfoFromApi, type GameInfo } from "./GameInfoService";
 
 export async function fetchGameState(): Promise<{ tiles: Piece[]; gameInfo: GameInfo }> {
   const [tiles, gameInfo] = await Promise.all([loadCurrentBoard(), getGameInfoFromApi()]);
+
+  if (gameInfo.TurnPlayer == -1){
+    const n: number = tiles.length;
+    for(let i=0; i<n; i++){
+      if (tiles[i] == "option"){
+        tiles[i] = "empty";
+      }
+    }
+  }
+
   return { tiles, gameInfo };
 }
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The system is intended to be an orchestration of three containerized application
 
 ## Usage
 
-This project is a work in progress, and currently only supports self-play.
+This project is a work in progress, and currently only supports playing against random move selection rather than a CNN model.
 
 From the root of the repo, run ```docker compose up --build``` to launch the three applications:
 


### PR DESCRIPTION
- Revised Gameplay SPA to only allow playing as Black
- Introduced polling (800ms) in the frontend to retrieve the updated board after opponent moves are made
- Introduced an Opponent Service in Game API, which performs random move selection asynchronously
- Playing against an automated opponent is now supported